### PR TITLE
[fix] 獲得コインが上限に達した後にもカードを引いてしまう不具合の修正

### DIFF
--- a/src/util/HighAndLowGame.java
+++ b/src/util/HighAndLowGame.java
@@ -27,12 +27,12 @@ public class HighAndLowGame {
    */
   public int execute() {
     while (true) {
+      // 現在の獲得コイン数が最大獲得コイン数を超えている場合：ゲーム終了
+      if (this.earnedCoinCount > this.maxWinCoin) return this.earnedCoinCount;
+      
       // まずはカードを引き、そのカードの番号を出力する
       List<Integer> cardList = new ArrayList<Integer>();
       cardList = this.getCard(cardList);
-
-      // 現在の獲得コイン数が最大獲得コイン数を超えている場合：ゲーム終了
-      if (this.earnedCoinCount > this.maxWinCoin) return this.earnedCoinCount;
 
       // ゲームを開始するかどうかユーザーに入力を求める
       while (true) {


### PR DESCRIPTION
ハイ＆ローゲームでは、獲得したコインが上限に達した時に強制終了するが、その終了前にカードを引く処理が入っていた。その不具合を修正した